### PR TITLE
:arrow_up: Bump mozilla-django-oidc-db to 0.6.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -142,7 +142,7 @@ markupsafe==1.1.1
     # via jinja2
 maykin-django-two-factor-auth[phonenumbers]==2.0.3
     # via -r requirements/base.in
-mozilla-django-oidc-db==0.5.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/base.in
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -212,7 +212,7 @@ markupsafe==1.1.1
     #   jinja2
 maykin-django-two-factor-auth[phonenumbers]==2.0.3
     # via -r requirements/base.txt
-mozilla-django-oidc-db==0.5.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/base.txt
 mozilla-django-oidc==1.2.4
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -257,7 +257,7 @@ maykin-django-two-factor-auth[phonenumbers]==2.0.3
     # via -r requirements/ci.txt
 mccabe==0.6.1
     # via flake8
-mozilla-django-oidc-db==0.5.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/ci.txt
 mozilla-django-oidc==1.2.4
     # via


### PR DESCRIPTION
Some extra functionality and bugfixes for the OpenID Connect integration, mentioned in the changelog: https://github.com/maykinmedia/mozilla-django-oidc-db/blob/master/CHANGELOG.rst