### PR TITLE
Helm Chart Enhancements

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,37 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.3.0
+        with:
+          charts_dir: deployment/kubernetes
+          config: cr.yaml
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ openapitools.json
 # Auto generated files
 src/resources.md
 src/swagger2.0.json
+
+# Helm
+**/charts/*.tgz
+**/Chart.lock

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "{{ .Name }}-chart-{{ .Version }}"

--- a/deployment/kubernetes/objecttypes/Chart.lock
+++ b/deployment/kubernetes/objecttypes/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.6
-digest: sha256:badf857ca373b0d4f44873070ce7a742e883a336d0b07d0a27b1c6b1bada19d9
-generated: "2021-02-02T14:59:54.585805775+01:00"
+  version: 10.2.8
+digest: sha256:1a4b35a4659ee70684ccf4c31ebcee02913666e5260ebf96ccb9d70490d79485
+generated: "2022-03-06T17:38:48.296495+01:00"

--- a/deployment/kubernetes/objecttypes/Chart.lock
+++ b/deployment/kubernetes/objecttypes/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 10.2.8
-digest: sha256:1a4b35a4659ee70684ccf4c31ebcee02913666e5260ebf96ccb9d70490d79485
-generated: "2022-03-06T17:38:48.296495+01:00"
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.0.1
+digest: sha256:1cabed29285e06020369c8eb40cc70085f107b1a8e0204513024cbf60aa5eca9
+generated: "2022-03-06T17:53:27.234253+01:00"

--- a/deployment/kubernetes/objecttypes/Chart.yaml
+++ b/deployment/kubernetes/objecttypes/Chart.yaml
@@ -3,7 +3,7 @@ name: objecttypes
 description: A Helm chart for Objecttypes API
 
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"
 
 dependencies:

--- a/deployment/kubernetes/objecttypes/Chart.yaml
+++ b/deployment/kubernetes/objecttypes/Chart.yaml
@@ -12,3 +12,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - postgresql
+  - name: redis
+    version: ~13.0.0
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - redis

--- a/deployment/kubernetes/objecttypes/templates/configmap.yaml
+++ b/deployment/kubernetes/objecttypes/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   DB_PORT: {{ .Values.settings.database.port | toString | quote }}
   DB_USER: {{ .Values.settings.database.username | toString | quote }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}
+  PGSSLMODE: {{ .Values.settings.database.sslmode | toString | quote }}
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   TWO_FACTOR_FORCE_OTP_ADMIN: {{ .Values.settings.twoFactorForceOtpAdmin | toString | quote }}

--- a/deployment/kubernetes/objecttypes/templates/configmap.yaml
+++ b/deployment/kubernetes/objecttypes/templates/configmap.yaml
@@ -13,3 +13,14 @@ data:
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
+  TWO_FACTOR_FORCE_OTP_ADMIN: {{ .Values.settings.twoFactorForceOtpAdmin | toString | quote }}
+  TWO_FACTOR_PATCH_ADMIN: {{ .Values.settings.twoFactorPatchAdmin | toString | quote }}
+  {{- if .Values.settings.admins }}
+  ADMINS: {{ .Values.settings.admins | toString | quote }}
+  {{- end }}
+  {{- if .Values.settings.subPath }}
+  SUBPATH: {{ .Values.settings.subPath | toString | quote }}
+  {{- end }}
+  {{- if .Values.settings.siteId }}
+  SITE_ID: {{ .Values.settings.siteId | toString | quote }}
+  {{- end }}

--- a/deployment/kubernetes/objecttypes/templates/configmap.yaml
+++ b/deployment/kubernetes/objecttypes/templates/configmap.yaml
@@ -11,3 +11,5 @@ data:
   DB_PORT: {{ .Values.settings.database.port | toString | quote }}
   DB_USER: {{ .Values.settings.database.username | toString | quote }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}
+  CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
+  CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}

--- a/deployment/kubernetes/objecttypes/templates/deployment.yaml
+++ b/deployment/kubernetes/objecttypes/templates/deployment.yaml
@@ -13,10 +13,12 @@ spec:
       {{- include "objecttypes.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "objecttypes.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/deployment/kubernetes/objecttypes/templates/deployment.yaml
+++ b/deployment/kubernetes/objecttypes/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "objecttypes.fullname" . }}
+                name: {{ .Values.existingSecret | default (include "objecttypes.fullname" .) }}
             - configMapRef:
                 name: {{ include "objecttypes.fullname" . }}
           ports:

--- a/deployment/kubernetes/objecttypes/templates/deployment.yaml
+++ b/deployment/kubernetes/objecttypes/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "objecttypes.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deployment/kubernetes/objecttypes/templates/deployment.yaml
+++ b/deployment/kubernetes/objecttypes/templates/deployment.yaml
@@ -51,10 +51,16 @@ spec:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "objecttypes.fullname" . | quote }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "objecttypes.fullname" . | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deployment/kubernetes/objecttypes/templates/secret.yaml
+++ b/deployment/kubernetes/objecttypes/templates/secret.yaml
@@ -9,4 +9,7 @@ type: Opaque
 data:
   DB_PASSWORD: {{ .Values.settings.database.password | toString | b64enc | quote }}
   SECRET_KEY: {{ .Values.settings.secretKey | toString | b64enc | quote }}
+  {{- if .Values.settings.sentry.dsn }}
+  SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/deployment/kubernetes/objecttypes/templates/secret.yaml
+++ b/deployment/kubernetes/objecttypes/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,4 @@ type: Opaque
 data:
   DB_PASSWORD: {{ .Values.settings.database.password | toString | b64enc | quote }}
   SECRET_KEY: {{ .Values.settings.secretKey | toString | b64enc | quote }}
-
+{{- end }}

--- a/deployment/kubernetes/objecttypes/values.yaml
+++ b/deployment/kubernetes/objecttypes/values.yaml
@@ -92,6 +92,7 @@ settings:
     username: objecttypes
     password: objecttypes
     name: objecttypes
+    sslmode: prefer
 
   cache:
     default: open-zaak-redis-master:6379/0

--- a/deployment/kubernetes/objecttypes/values.yaml
+++ b/deployment/kubernetes/objecttypes/values.yaml
@@ -21,6 +21,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/deployment/kubernetes/objecttypes/values.yaml
+++ b/deployment/kubernetes/objecttypes/values.yaml
@@ -12,6 +12,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+existingSecret: null
+
 serviceAccount:
   create: true
   annotations: {}

--- a/deployment/kubernetes/objecttypes/values.yaml
+++ b/deployment/kubernetes/objecttypes/values.yaml
@@ -1,5 +1,6 @@
 tags:
   postgresql: true
+  redis: true
 
 replicaCount: 1
 
@@ -87,6 +88,10 @@ settings:
     password: objecttypes
     name: objecttypes
 
+  cache:
+    default: open-zaak-redis-master:6379/0
+    axes: open-zaak-redis-master:6379/0
+
 
 #########################
 ## PostgreSQL subchart ##
@@ -95,3 +100,23 @@ postgresql:
   postgresqlDatabase: objecttypes
   postgresqlUsername: objecttypes
   postgresqlPassword: objecttypes
+
+
+##################
+# Redis subchart #
+##################
+
+redis:
+  usePassword: false
+
+  cluster:
+    enabled: false
+
+  persistence:
+    existingClaim: null
+
+  master:
+    persistence:
+      enabled: false
+      size: 1Gi
+      

--- a/deployment/kubernetes/objecttypes/values.yaml
+++ b/deployment/kubernetes/objecttypes/values.yaml
@@ -79,7 +79,7 @@ affinity: {}
 
 settings:
   secretKey: NOT-SO-SECRET
-  allowedHosts: "*"
+  allowedHosts: "objecttypes"
   admins: ""
   siteId: ""
   subPath: ""

--- a/deployment/kubernetes/objecttypes/values.yaml
+++ b/deployment/kubernetes/objecttypes/values.yaml
@@ -80,6 +80,11 @@ affinity: {}
 settings:
   secretKey: NOT-SO-SECRET
   allowedHosts: "*"
+  admins: ""
+  siteId: ""
+  subPath: ""
+  twoFactorForceOtpAdmin: "True"
+  twoFactorPatchAdmin: "False"
 
   database:
     host: objecttypes-postgresql
@@ -91,6 +96,9 @@ settings:
   cache:
     default: open-zaak-redis-master:6379/0
     axes: open-zaak-redis-master:6379/0
+  
+  sentry:
+    dsn: ""
 
 
 #########################


### PR DESCRIPTION
This PR contains several enhancements to the ObjectTypes Helm chart. 
Please see the commit descriptions for details. 

As for the chart-releaser (6a19c966a0515d670716cce1e2e4a2ad71a69566), before merging to master, please make sure that you have created a `gh-pages` branch and in the Repo's `Settings > Pages` you've changed the `Source Branch` to `gh-pages`. For more details see [chart-releaser prerequisites](https://github.com/helm/chart-releaser-action#pre-requisites).
Afterwards the chart-releaser will detect any future changes in the chart and will publish the chart accordingly. This means a chart repo is available and `helm repo add objecttypes https://maykinmedia.github.io/objecttypes-api/` can be used. 

_**Testing**_
All enhancements have been successfully tested on the Gemeente Utrecht environment. 