### PR TITLE
:bug: Unique name for session ID cookie

### DIFF
--- a/src/objecttypes/conf/base.py
+++ b/src/objecttypes/conf/base.py
@@ -296,6 +296,8 @@ AUTHENTICATION_BACKENDS = [
     "mozilla_django_oidc_db.backends.OIDCAuthenticationBackend",
 ]
 
+SESSION_COOKIE_NAME = "objecttypes_sessionid"
+
 LOGIN_REDIRECT_URL = reverse_lazy("admin:index")
 LOGOUT_REDIRECT_URL = reverse_lazy("admin:index")
 


### PR DESCRIPTION
previously the `SESSION_COOKIE_NAME` for objects and objecttypes were the same, making it impossible to be logged into both apps simultaneously