### PR TITLE
:whale: Fix SECRET_KEY interpolation bug in docker quickstart

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -11,7 +11,7 @@ services:
     image: maykinmedia/objecttypes-api:latest
     environment:
       - DJANGO_SETTINGS_MODULE=objecttypes.conf.docker
-      - SECRET_KEY=${SECRET_KEY:-fgv=c0hz&tl*8*3m3893@m+1pstrvidc9e^5@fpspmg%cy$15d}
+      - SECRET_KEY=${SECRET_KEY:-fgv=c0hz&tl*8*3m3893@m+1pstrvidc9e^5@fpspmg%cyz15d}
       - ALLOWED_HOSTS=*
     ports:
       - 8001:8000


### PR DESCRIPTION
the dollar sign in the secret key caused docker-compose-quickstart.yml to crash