### PR TITLE
:whale: Add SUBPATH envvar to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - CACHE_DEFAULT=redis:6379/0
       - CACHE_AXES=redis:6379/0
       - DISABLE_2FA=yes
+      - SUBPATH=${SUBPATH:-/}
       # setup_configuration env vars
       - OBJECTTYPES_DOMAIN=web:8000
       - OBJECTTYPES_ORGANIZATION=ObjectTypes


### PR DESCRIPTION
Related to https://github.com/open-zaak/open-zaak/issues/1629, I wanted to test if SUBPATH works for Objecttypes now as well