### PR TITLE
 ✨ [open-zaak/open-zaak#1649] Pick up envvar docs from OAf

### DIFF
--- a/docs/env_config.rst
+++ b/docs/env_config.rst
@@ -1,0 +1,84 @@
+.. _installation_env_config:
+
+===================================
+Environment configuration reference
+===================================
+
+
+
+Available environment variables
+===============================
+
+
+Optional
+========
+
+* ``SITE_ID``: The database ID of the site object. You usually won't have to touch this. Defaults to: ``1``
+* ``DEBUG``: Only set this to True on a local development environment. Various other security settings are derived from this setting!. Defaults to: ``False``
+* ``ALLOWED_HOSTS``: a comma separated (without spaces!) list of domains that serve the installation. Used to protect against Host header attacks. Defaults to: ``(empty string)``
+* ``USE_X_FORWARDED_HOST``: whether to grab the domain/host from the X-Forwarded-Host header or not. This header is typically set by reverse proxies (such as nginx, traefik, Apache...). Default False - this is a header that can be spoofed and you need to ensure you control it before enabling this. Defaults to: ``False``
+* ``IS_HTTPS``: Used to construct absolute URLs and controls a variety of security settings. Defaults to: ``False``
+* ``CACHE_DEFAULT``: redis cache address for the default cache. Defaults to: ``localhost:6379/0``
+* ``CACHE_AXES``: redis cache address for the brute force login protection cache. Defaults to: ``localhost:6379/0``
+* ``EMAIL_HOST``: hostname for the outgoing e-mail server. Defaults to: ``localhost``
+* ``EMAIL_PORT``: port number of the outgoing e-mail server. Note that if you're on Google Cloud, sending e-mail via port 25 is completely blocked and you should use 487 for TLS. Defaults to: ``25``
+* ``EMAIL_HOST_USER``: username to connect to the mail server. Defaults to: ``(empty string)``
+* ``EMAIL_HOST_PASSWORD``: password to connect to the mail server. Defaults to: ``(empty string)``
+* ``EMAIL_USE_TLS``: whether to use TLS or not to connect to the mail server. Should be True if you're changing the EMAIL_PORT to 487. Defaults to: ``False``
+* ``DEFAULT_FROM_EMAIL``: The default email address from which emails are sent. Defaults to: ``objecttypes@example.com``
+* ``LOG_STDOUT``: whether to log to stdout or not. Defaults to: ``False``
+* ``LOG_LEVEL``: control the verbosity of logging output. Available values are CRITICAL, ERROR, WARNING, INFO and DEBUG. Defaults to: ``WARNING``
+* ``LOG_QUERIES``: enable (query) logging at the database backend level. Note that you must also set DEBUG=1, which should be done very sparingly!. Defaults to: ``False``
+* ``LOG_REQUESTS``: enable logging of the outgoing requests. Defaults to: ``False``
+* ``ENVIRONMENT``: An identifier for the environment, displayed in the admin depending on the settings module used and included in the error monitoring (see SENTRY_DSN). The default is set according to DJANGO_SETTINGS_MODULE. Defaults to: ``(empty string)``
+* ``SUBPATH``: The subpath the application will be mounted on. Defaults to: ``None``
+* ``RELEASE``: The version number or commit hash of the application (this is also send to Sentry). Defaults to: ``None``
+* ``NUM_PROXIES``: the number of reverse proxies in front of the application, as an integer. This is used to determine the actual client IP adres. On Kubernetes with an ingress you typically want to set this to 2. Defaults to: ``1``
+* ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``
+* ``NOTIFICATIONS_DISABLED``: if this variable is set to true, yes or 1, the notification mechanism will be disabled. Defaults to: ``False``
+* ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``
+* ``LOG_OUTGOING_REQUESTS_DB_SAVE``: Whether or not outgoing request logs should be saved to the database. Defaults to: ``False``
+* ``LOG_OUTGOING_REQUESTS_MAX_AGE``: The amount of time after which request logs should be deleted from the database. Defaults to: ``7``
+* ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this. Defaults to: ``None``
+
+
+Required
+========
+
+* ``SECRET_KEY``: Secret key that's used for certain cryptographic utilities. You should generate one via `miniwebtool <https://www.miniwebtool.com/django-secret-key-generator>`_.
+
+
+Database
+========
+
+* ``DB_NAME``: name of the PostgreSQL database. Defaults to: ``objecttypes``
+* ``DB_USER``: username of the database user. Defaults to: ``objecttypes``
+* ``DB_PASSWORD``: password of the database user. Defaults to: ``objecttypes``
+* ``DB_HOST``: hostname of the PostgreSQL database. Defaults to: ``localhost``
+* ``DB_PORT``: port number of the database. Defaults to: ``5432``
+
+
+Cross-Origin-Resource-Sharing
+=============================
+
+* ``CORS_ALLOW_ALL_ORIGINS``: allow cross-domain access from any client. Defaults to: ``False``
+* ``CORS_ALLOWED_ORIGINS``: explicitly list the allowed origins for cross-domain requests. Example: http://localhost:3000,https://some-app.gemeente.nl. Defaults to: ``[]``
+* ``CORS_ALLOWED_ORIGIN_REGEXES``: same as ``CORS_ALLOWED_ORIGINS``, but supports regular expressions. Defaults to: ``[]``
+* ``CORS_EXTRA_ALLOW_HEADERS``: headers that are allowed to be sent as part of the cross-domain request. By default, Authorization, Accept-Crs and Content-Crs are already included. The value of this variable is added to these already included headers. Defaults to: ``[]``
+
+
+Celery
+======
+
+* ``CELERY_RESULT_BACKEND``: the URL of the broker that will be used to actually send the notifications. Defaults to: ``redis://localhost:6379/1``
+
+
+Elastic APM
+===========
+
+* ``ELASTIC_APM_SERVER_URL``: URL where Elastic APM is hosted. Defaults to: ``None``
+* ``ELASTIC_APM_SERVICE_NAME``: Name of the service for this application in Elastic APM. Defaults to: ``objecttypes - local``
+* ``ELASTIC_APM_SECRET_TOKEN``: Token used to communicate with Elastic APM. Defaults to: ``default``
+* ``ELASTIC_APM_TRANSACTION_SAMPLE_RATE``: By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, set the sample rate to a value between 0.0 and 1.0. Defaults to: ``0.1``
+
+

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
-open-api-framework
+git+https://github.com/maykinmedia/open-api-framework.git@feature/autodoc
 
 # Core python libraries
 jsonschema

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -146,7 +146,9 @@ django-rest-framework-condition==0.1.1
 django-sendfile2==0.7.0
     # via django-privates
 django-setup-configuration==0.1.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   open-api-framework
 django-simple-certmanager==2.0.0
     # via zgw-consumers
 django-solo==2.0.0
@@ -237,7 +239,7 @@ mozilla-django-oidc-db==0.16.0
     # via open-api-framework
 notifications-api-common==0.2.2
     # via commonground-api-common
-open-api-framework==0.3.0
+open_api_framework @ git+https://github.com/maykinmedia/open-api-framework.git@feature/autodoc
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -225,7 +225,9 @@ django-sendfile2==0.7.0
     #   -r requirements/base.txt
     #   django-privates
 django-setup-configuration==0.1.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   open-api-framework
 django-simple-certmanager==2.0.0
     # via
     #   -r requirements/base.txt
@@ -379,7 +381,7 @@ notifications-api-common==0.2.2
     # via
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.3.0
+open_api_framework @ git+https://github.com/maykinmedia/open-api-framework.git@feature/autodoc
     # via -r requirements/base.txt
 orderedmultidict==1.0.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -249,7 +249,9 @@ django-sendfile2==0.7.0
     #   -r requirements/ci.txt
     #   django-privates
 django-setup-configuration==0.1.0
-    # via -r requirements/ci.txt
+    # via
+    #   -r requirements/ci.txt
+    #   open-api-framework
 django-simple-certmanager==2.0.0
     # via
     #   -r requirements/ci.txt
@@ -422,7 +424,7 @@ notifications-api-common==0.2.2
     # via
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.3.0
+open_api_framework @ git+https://github.com/maykinmedia/open-api-framework.git@feature/autodoc
     # via -r requirements/ci.txt
 orderedmultidict==1.0.1
     # via

--- a/src/objecttypes/conf/base.py
+++ b/src/objecttypes/conf/base.py
@@ -67,18 +67,18 @@ SETUP_CONFIGURATION_STEPS = [
 
 # setup_configuration command
 # sites config
-SITES_CONFIG_ENABLE = config("SITES_CONFIG_ENABLE", default=True)
-OBJECTTYPES_DOMAIN = config("OBJECTTYPES_DOMAIN", "")
-OBJECTTYPES_ORGANIZATION = config("OBJECTTYPES_ORGANIZATION", "")
+SITES_CONFIG_ENABLE = config("SITES_CONFIG_ENABLE", default=True, add_to_docs=False)
+OBJECTTYPES_DOMAIN = config("OBJECTTYPES_DOMAIN", "", add_to_docs=False)
+OBJECTTYPES_ORGANIZATION = config("OBJECTTYPES_ORGANIZATION", "", add_to_docs=False)
 # objects auth config
 OBJECTS_OBJECTTYPES_CONFIG_ENABLE = config(
-    "OBJECTS_OBJECTTYPES_CONFIG_ENABLE", default=True
+    "OBJECTS_OBJECTTYPES_CONFIG_ENABLE", default=True, add_to_docs=False
 )
-OBJECTS_OBJECTTYPES_TOKEN = config("OBJECTS_OBJECTTYPES_TOKEN", "")
-OBJECTS_OBJECTTYPES_PERSON = config("OBJECTS_OBJECTTYPES_PERSON", "")
-OBJECTS_OBJECTTYPES_EMAIL = config("OBJECTS_OBJECTTYPES_EMAIL", "")
+OBJECTS_OBJECTTYPES_TOKEN = config("OBJECTS_OBJECTTYPES_TOKEN", "", add_to_docs=False)
+OBJECTS_OBJECTTYPES_PERSON = config("OBJECTS_OBJECTTYPES_PERSON", "", add_to_docs=False)
+OBJECTS_OBJECTTYPES_EMAIL = config("OBJECTS_OBJECTTYPES_EMAIL", "", add_to_docs=False)
 # Demo User Configuration
-DEMO_CONFIG_ENABLE = config("DEMO_CONFIG_ENABLE", default=DEBUG)
-DEMO_TOKEN = config("DEMO_TOKEN", "")
-DEMO_PERSON = config("DEMO_PERSON", "")
-DEMO_EMAIL = config("DEMO_EMAIL", "")
+DEMO_CONFIG_ENABLE = config("DEMO_CONFIG_ENABLE", default=DEBUG, add_to_docs=False)
+DEMO_TOKEN = config("DEMO_TOKEN", "", add_to_docs=False)
+DEMO_PERSON = config("DEMO_PERSON", "", add_to_docs=False)
+DEMO_EMAIL = config("DEMO_EMAIL", "", add_to_docs=False)


### PR DESCRIPTION
Related PR in OAF: https://github.com/maykinmedia/open-api-framework/pull/22

I'm not sure what the best way is to handle this for Objecttypes specifically, since Objecttypes doesn't have it's own docs (they are included in the Objects API repo)