### PR TITLE
⬆️ Upgrade open-api-framework to 0.4.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -146,7 +146,9 @@ django-rest-framework-condition==0.1.1
 django-sendfile2==0.7.0
     # via django-privates
 django-setup-configuration==0.1.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   open-api-framework
 django-simple-certmanager==2.0.0
     # via zgw-consumers
 django-solo==2.0.0
@@ -237,7 +239,7 @@ mozilla-django-oidc-db==0.16.0
     # via open-api-framework
 notifications-api-common==0.2.2
     # via commonground-api-common
-open-api-framework==0.3.0
+open-api-framework==0.4.2
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -225,7 +225,9 @@ django-sendfile2==0.7.0
     #   -r requirements/base.txt
     #   django-privates
 django-setup-configuration==0.1.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   open-api-framework
 django-simple-certmanager==2.0.0
     # via
     #   -r requirements/base.txt
@@ -379,7 +381,7 @@ notifications-api-common==0.2.2
     # via
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.3.0
+open-api-framework==0.4.2
     # via -r requirements/base.txt
 orderedmultidict==1.0.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -249,7 +249,9 @@ django-sendfile2==0.7.0
     #   -r requirements/ci.txt
     #   django-privates
 django-setup-configuration==0.1.0
-    # via -r requirements/ci.txt
+    # via
+    #   -r requirements/ci.txt
+    #   open-api-framework
 django-simple-certmanager==2.0.0
     # via
     #   -r requirements/ci.txt
@@ -422,7 +424,7 @@ notifications-api-common==0.2.2
     # via
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.3.0
+open-api-framework==0.4.2
     # via -r requirements/ci.txt
 orderedmultidict==1.0.1
     # via

--- a/src/objecttypes/fixtures/default_admin_index.json
+++ b/src/objecttypes/fixtures/default_admin_index.json
@@ -13,6 +13,14 @@
             [
                 "auth",
                 "group"
+            ],
+            [
+                "otp_totp",
+                "totpdevice"
+            ],
+            [
+                "two_factor_webauthn",
+                "webauthndevice"
             ]
         ]
     }

--- a/src/objecttypes/urls.py
+++ b/src/objecttypes/urls.py
@@ -8,7 +8,7 @@ from django.urls import include, path
 from django.views.generic.base import TemplateView
 
 from maykin_2fa import monkeypatch_admin
-from maykin_2fa.urls import urlpatterns as maykin_2fa_urlpatterns
+from maykin_2fa.urls import urlpatterns as maykin_2fa_urlpatterns, webauthn_urlpatterns
 from rest_framework.settings import api_settings
 
 handler500 = "objecttypes.utils.views.server_error"
@@ -30,6 +30,7 @@ urlpatterns = [
         name="password_reset_done",
     ),
     path("admin/", include((maykin_2fa_urlpatterns, "maykin_2fa"))),
+    path("admin/", include((webauthn_urlpatterns, "two_factor"))),
     path("admin/", admin.site.urls),
     path(
         "reset/<uidb64>/<token>/",


### PR DESCRIPTION
Viewing `Application groups` in the admin was broken, because Open API Framework did not add `ordered_model` to `INSTALLED_APPS`