### PR TITLE
:green_heart: [maykinmedia/open-api-framework#116] Fix codecov publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Publish coverage report
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   store-reusable-workflow-vars:
     name: create values which can be passed through a reusable workflow


### PR DESCRIPTION
by explicitly using the CODECOV_TOKEN

Fixes maykinmedia/open-api-framework#116 partially

**Changes**
* Fix codecov publish

