### PR TITLE
:whale: [#562] Upgrade from debian-bullseye to debian-bookworm in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - Compile needed python dependencies
-FROM python:3.11-slim-bullseye AS build
+FROM python:3.11-slim-bookworm AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
@@ -32,7 +32,7 @@ RUN npm run build
 
 
 # Stage 3 - Build docker image suitable for execution and deployment
-FROM python:3.11-slim-bullseye AS production
+FROM python:3.11-slim-bookworm AS production
 
 # Stage 3.1 - Set up the needed production dependencies
 # install all the dependencies for GeoDjango


### PR DESCRIPTION
bookworm is a newer version and this is already in use for Open Zaak and other applications as well

Related issue: https://github.com/maykinmedia/open-api-framework/issues/125

