### PR TITLE
:construction_worker: Disable OAS lint job due to vulnerability

### DIFF
--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,32 +1,32 @@
-name: OAS
+# name: OAS
 
-on:
-  push:
-    branches:
-      - master
-      - stable/*
-    tags:
-      - '*'
-  pull_request:
-  workflow_dispatch:
+# on:
+#   push:
+#     branches:
+#       - master
+#       - stable/*
+#     tags:
+#       - '*'
+#   pull_request:
+#   workflow_dispatch:
 
-# least privilege as default, should be overridden per job if necessary
-permissions:
-  contents: read
+# # least privilege as default, should be overridden per job if necessary
+# permissions:
+#   contents: read
 
-jobs:
-  oas:
-    name: Checks
-    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
-    with:
-      python-version: '3.12'
-      django-settings-module: objecttypes.conf.ci
-      oas-generate-command: ./bin/generate_schema.sh
-      schema-path: src/objecttypes/api/v2/openapi.yaml
-      oas-artifact-name: objecttypes-api-oas
-      node-version-file: '.nvmrc'
-      spectral-version: '^6.15.0'
-      openapi-to-postman-version: '^5.0.0'
-      postman-artifact-name: objecttypes-api-postman-collection
-      openapi-generator-version: '^2.20.0'
-      spectral-ruleset: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml
+# jobs:
+#   oas:
+#     name: Checks
+#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+#     with:
+#       python-version: '3.12'
+#       django-settings-module: objecttypes.conf.ci
+#       oas-generate-command: ./bin/generate_schema.sh
+#       schema-path: src/objecttypes/api/v2/openapi.yaml
+#       oas-artifact-name: objecttypes-api-oas
+#       node-version-file: '.nvmrc'
+#       spectral-version: '^6.15.0'
+#       openapi-to-postman-version: '^5.0.0'
+#       postman-artifact-name: objecttypes-api-postman-collection
+#       openapi-generator-version: '^2.20.0'
+#       spectral-ruleset: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml


### PR DESCRIPTION
asyncapi/specs was compromised and spectral installs this, not pinned to a specific version

Fixes #

**Changes**

[Describe the changes here]

